### PR TITLE
Use instrinsicContentSize rather than manipulating autolayout constraints

### DIFF
--- a/Examples/AutolayoutExample/AutolayoutExample/Base.lproj/Main.storyboard
+++ b/Examples/AutolayoutExample/AutolayoutExample/Base.lproj/Main.storyboard
@@ -1,7 +1,8 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="7531" systemVersion="14B25" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" initialViewController="BYZ-38-t0r">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="10116" systemVersion="15E65" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" initialViewController="BYZ-38-t0r">
     <dependencies>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="7520"/>
+        <deployment identifier="iOS"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="10085"/>
         <capability name="Constraints to layout margins" minToolsVersion="6.0"/>
     </dependencies>
     <scenes>
@@ -17,12 +18,9 @@
                         <rect key="frame" x="0.0" y="0.0" width="600" height="600"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
-                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="XRo-Ub-Gua" customClass="KSTokenView" customModule="AutolayoutExample" customModuleProvider="target">
-                                <rect key="frame" x="16" y="16" width="568" height="30"/>
+                            <view contentMode="scaleToFill" placeholderIntrinsicWidth="infinite" placeholderIntrinsicHeight="30" translatesAutoresizingMaskIntoConstraints="NO" id="XRo-Ub-Gua" customClass="KSTokenView" customModule="AutolayoutExample" customModuleProvider="target">
+                                <rect key="frame" x="20" y="16" width="560" height="30"/>
                                 <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
-                                <constraints>
-                                    <constraint firstAttribute="height" constant="30" id="uQi-OS-cK1"/>
-                                </constraints>
                             </view>
                         </subviews>
                         <color key="backgroundColor" red="0.2901960784" green="0.6705882353" blue="0.96862745100000003" alpha="1" colorSpace="calibratedRGB"/>

--- a/Examples/HorizontalExample/HorizontalExample/Base.lproj/Main.storyboard
+++ b/Examples/HorizontalExample/HorizontalExample/Base.lproj/Main.storyboard
@@ -1,7 +1,9 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="6250" systemVersion="14B25" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" initialViewController="BYZ-38-t0r">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="10116" systemVersion="15E65" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" initialViewController="BYZ-38-t0r">
     <dependencies>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="6244"/>
+        <deployment identifier="iOS"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="10085"/>
+        <capability name="Constraints to layout margins" minToolsVersion="6.0"/>
     </dependencies>
     <scenes>
         <!--View Controller-->
@@ -16,12 +18,19 @@
                         <rect key="frame" x="0.0" y="0.0" width="600" height="600"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
-                            <view contentMode="scaleToFill" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="q8l-qS-cLx" customClass="KSTokenView" customModule="HorizontalExample" customModuleProvider="target">
-                                <rect key="frame" x="10" y="20" width="300" height="30"/>
+                            <view contentMode="scaleToFill" placeholderIntrinsicWidth="infinite" placeholderIntrinsicHeight="30" translatesAutoresizingMaskIntoConstraints="NO" id="q8l-qS-cLx" customClass="KSTokenView" customModule="HorizontalExample" customModuleProvider="target">
+                                <rect key="frame" x="20" y="20" width="290" height="30"/>
                                 <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                                <constraints>
+                                    <constraint firstAttribute="width" constant="290" id="MIG-AB-uKb"/>
+                                </constraints>
                             </view>
                         </subviews>
                         <color key="backgroundColor" red="0.2901960784" green="0.6705882353" blue="0.96862745100000003" alpha="1" colorSpace="calibratedRGB"/>
+                        <constraints>
+                            <constraint firstItem="q8l-qS-cLx" firstAttribute="top" secondItem="y3c-jy-aDJ" secondAttribute="bottom" id="Fm4-GD-Mkb"/>
+                            <constraint firstItem="q8l-qS-cLx" firstAttribute="leading" secondItem="8bC-Xf-vdC" secondAttribute="leadingMargin" id="qoI-tL-4dz"/>
+                        </constraints>
                     </view>
                     <connections>
                         <outlet property="tokenView" destination="q8l-qS-cLx" id="hhQ-cG-Rig"/>

--- a/Examples/ObjCExample/ObjCExample/Base.lproj/Main.storyboard
+++ b/Examples/ObjCExample/ObjCExample/Base.lproj/Main.storyboard
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="6250" systemVersion="14B25" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" initialViewController="BYZ-38-t0r">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="10116" systemVersion="15E65" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" initialViewController="BYZ-38-t0r">
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="6244"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="10085"/>
         <capability name="Constraints to layout margins" minToolsVersion="6.0"/>
     </dependencies>
     <scenes>
@@ -18,12 +18,11 @@
                         <rect key="frame" x="0.0" y="0.0" width="600" height="600"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
-                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="UtK-7j-aLu" customClass="KSTokenView" customModule="ObjCExample" customModuleProvider="target">
-                                <rect key="frame" x="26" y="28" width="300" height="30"/>
+                            <view contentMode="scaleToFill" placeholderIntrinsicWidth="infinite" placeholderIntrinsicHeight="30" translatesAutoresizingMaskIntoConstraints="NO" id="UtK-7j-aLu" customClass="KSTokenView" customModule="ObjCExample" customModuleProvider="target">
+                                <rect key="frame" x="30" y="28" width="300" height="30"/>
                                 <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                                 <constraints>
                                     <constraint firstAttribute="width" constant="300" id="zOO-f9-HMr"/>
-                                    <constraint firstAttribute="height" constant="30" id="zQr-gt-oQJ"/>
                                 </constraints>
                             </view>
                         </subviews>

--- a/Examples/StackViewExample/StackViewExample.xcodeproj/project.pbxproj
+++ b/Examples/StackViewExample/StackViewExample.xcodeproj/project.pbxproj
@@ -1,0 +1,463 @@
+// !$*UTF8*$!
+{
+	archiveVersion = 1;
+	classes = {
+	};
+	objectVersion = 46;
+	objects = {
+
+/* Begin PBXBuildFile section */
+		CB9350021AE5032700756186 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB9350011AE5032700756186 /* AppDelegate.swift */; };
+		CB9350041AE5032700756186 /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB9350031AE5032700756186 /* ViewController.swift */; };
+		CB9350071AE5032800756186 /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = CB9350051AE5032800756186 /* Main.storyboard */; };
+		CB9350091AE5032800756186 /* Images.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = CB9350081AE5032800756186 /* Images.xcassets */; };
+		CB93500C1AE5032900756186 /* LaunchScreen.xib in Resources */ = {isa = PBXBuildFile; fileRef = CB93500A1AE5032900756186 /* LaunchScreen.xib */; };
+		CB9350181AE5032900756186 /* StackViewExampleTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB9350171AE5032900756186 /* StackViewExampleTests.swift */; };
+		CB9350261AE5037F00756186 /* KSToken.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB9350221AE5037F00756186 /* KSToken.swift */; };
+		CB9350271AE5037F00756186 /* KSTokenField.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB9350231AE5037F00756186 /* KSTokenField.swift */; };
+		CB9350281AE5037F00756186 /* KSTokenView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB9350241AE5037F00756186 /* KSTokenView.swift */; };
+		CB9350291AE5037F00756186 /* KSUtils.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB9350251AE5037F00756186 /* KSUtils.swift */; };
+		CB93502B1AE5045E00756186 /* List.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB93502A1AE5045E00756186 /* List.swift */; };
+/* End PBXBuildFile section */
+
+/* Begin PBXContainerItemProxy section */
+		CB9350121AE5032900756186 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = CB934FF41AE5032400756186 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = CB934FFB1AE5032500756186;
+			remoteInfo = AutolayoutExample;
+		};
+/* End PBXContainerItemProxy section */
+
+/* Begin PBXFileReference section */
+		CB934FFC1AE5032600756186 /* StackViewExample.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = StackViewExample.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		CB9350001AE5032700756186 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		CB9350011AE5032700756186 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
+		CB9350031AE5032700756186 /* ViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ViewController.swift; sourceTree = "<group>"; };
+		CB9350061AE5032800756186 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/Main.storyboard; sourceTree = "<group>"; };
+		CB9350081AE5032800756186 /* Images.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Images.xcassets; sourceTree = "<group>"; };
+		CB93500B1AE5032900756186 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.xib; name = Base; path = Base.lproj/LaunchScreen.xib; sourceTree = "<group>"; };
+		CB9350111AE5032900756186 /* StackViewExampleTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = StackViewExampleTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		CB9350161AE5032900756186 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		CB9350171AE5032900756186 /* StackViewExampleTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StackViewExampleTests.swift; sourceTree = "<group>"; };
+		CB9350221AE5037F00756186 /* KSToken.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = KSToken.swift; sourceTree = "<group>"; };
+		CB9350231AE5037F00756186 /* KSTokenField.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = KSTokenField.swift; sourceTree = "<group>"; };
+		CB9350241AE5037F00756186 /* KSTokenView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = KSTokenView.swift; sourceTree = "<group>"; };
+		CB9350251AE5037F00756186 /* KSUtils.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = KSUtils.swift; sourceTree = "<group>"; };
+		CB93502A1AE5045E00756186 /* List.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = List.swift; path = ../../List.swift; sourceTree = "<group>"; };
+/* End PBXFileReference section */
+
+/* Begin PBXFrameworksBuildPhase section */
+		CB934FF91AE5032500756186 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		CB93500E1AE5032900756186 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXFrameworksBuildPhase section */
+
+/* Begin PBXGroup section */
+		CB934FF31AE5032300756186 = {
+			isa = PBXGroup;
+			children = (
+				CB9350211AE5037F00756186 /* KSTokenView */,
+				CB934FFE1AE5032600756186 /* StackViewExample */,
+				CB9350141AE5032900756186 /* StackViewExampleTests */,
+				CB934FFD1AE5032600756186 /* Products */,
+			);
+			sourceTree = "<group>";
+		};
+		CB934FFD1AE5032600756186 /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				CB934FFC1AE5032600756186 /* StackViewExample.app */,
+				CB9350111AE5032900756186 /* StackViewExampleTests.xctest */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+		CB934FFE1AE5032600756186 /* StackViewExample */ = {
+			isa = PBXGroup;
+			children = (
+				CB93502A1AE5045E00756186 /* List.swift */,
+				CB9350011AE5032700756186 /* AppDelegate.swift */,
+				CB9350031AE5032700756186 /* ViewController.swift */,
+				CB9350051AE5032800756186 /* Main.storyboard */,
+				CB9350081AE5032800756186 /* Images.xcassets */,
+				CB93500A1AE5032900756186 /* LaunchScreen.xib */,
+				CB934FFF1AE5032700756186 /* Supporting Files */,
+			);
+			path = StackViewExample;
+			sourceTree = "<group>";
+		};
+		CB934FFF1AE5032700756186 /* Supporting Files */ = {
+			isa = PBXGroup;
+			children = (
+				CB9350001AE5032700756186 /* Info.plist */,
+			);
+			name = "Supporting Files";
+			sourceTree = "<group>";
+		};
+		CB9350141AE5032900756186 /* StackViewExampleTests */ = {
+			isa = PBXGroup;
+			children = (
+				CB9350171AE5032900756186 /* StackViewExampleTests.swift */,
+				CB9350151AE5032900756186 /* Supporting Files */,
+			);
+			path = StackViewExampleTests;
+			sourceTree = "<group>";
+		};
+		CB9350151AE5032900756186 /* Supporting Files */ = {
+			isa = PBXGroup;
+			children = (
+				CB9350161AE5032900756186 /* Info.plist */,
+			);
+			name = "Supporting Files";
+			sourceTree = "<group>";
+		};
+		CB9350211AE5037F00756186 /* KSTokenView */ = {
+			isa = PBXGroup;
+			children = (
+				CB9350221AE5037F00756186 /* KSToken.swift */,
+				CB9350231AE5037F00756186 /* KSTokenField.swift */,
+				CB9350241AE5037F00756186 /* KSTokenView.swift */,
+				CB9350251AE5037F00756186 /* KSUtils.swift */,
+			);
+			name = KSTokenView;
+			path = ../../KSTokenView;
+			sourceTree = "<group>";
+		};
+/* End PBXGroup section */
+
+/* Begin PBXNativeTarget section */
+		CB934FFB1AE5032500756186 /* StackViewExample */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = CB93501B1AE5032900756186 /* Build configuration list for PBXNativeTarget "StackViewExample" */;
+			buildPhases = (
+				CB934FF81AE5032500756186 /* Sources */,
+				CB934FF91AE5032500756186 /* Frameworks */,
+				CB934FFA1AE5032500756186 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = StackViewExample;
+			productName = AutolayoutExample;
+			productReference = CB934FFC1AE5032600756186 /* StackViewExample.app */;
+			productType = "com.apple.product-type.application";
+		};
+		CB9350101AE5032900756186 /* StackViewExampleTests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = CB93501E1AE5032900756186 /* Build configuration list for PBXNativeTarget "StackViewExampleTests" */;
+			buildPhases = (
+				CB93500D1AE5032900756186 /* Sources */,
+				CB93500E1AE5032900756186 /* Frameworks */,
+				CB93500F1AE5032900756186 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				CB9350131AE5032900756186 /* PBXTargetDependency */,
+			);
+			name = StackViewExampleTests;
+			productName = AutolayoutExampleTests;
+			productReference = CB9350111AE5032900756186 /* StackViewExampleTests.xctest */;
+			productType = "com.apple.product-type.bundle.unit-test";
+		};
+/* End PBXNativeTarget section */
+
+/* Begin PBXProject section */
+		CB934FF41AE5032400756186 /* Project object */ = {
+			isa = PBXProject;
+			attributes = {
+				LastSwiftUpdateCheck = 0700;
+				LastUpgradeCheck = 0700;
+				ORGANIZATIONNAME = "Khawar Shahzad";
+				TargetAttributes = {
+					CB934FFB1AE5032500756186 = {
+						CreatedOnToolsVersion = 6.3;
+					};
+					CB9350101AE5032900756186 = {
+						CreatedOnToolsVersion = 6.3;
+						TestTargetID = CB934FFB1AE5032500756186;
+					};
+				};
+			};
+			buildConfigurationList = CB934FF71AE5032400756186 /* Build configuration list for PBXProject "StackViewExample" */;
+			compatibilityVersion = "Xcode 3.2";
+			developmentRegion = English;
+			hasScannedForEncodings = 0;
+			knownRegions = (
+				en,
+				Base,
+			);
+			mainGroup = CB934FF31AE5032300756186;
+			productRefGroup = CB934FFD1AE5032600756186 /* Products */;
+			projectDirPath = "";
+			projectRoot = "";
+			targets = (
+				CB934FFB1AE5032500756186 /* StackViewExample */,
+				CB9350101AE5032900756186 /* StackViewExampleTests */,
+			);
+		};
+/* End PBXProject section */
+
+/* Begin PBXResourcesBuildPhase section */
+		CB934FFA1AE5032500756186 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				CB9350071AE5032800756186 /* Main.storyboard in Resources */,
+				CB93500C1AE5032900756186 /* LaunchScreen.xib in Resources */,
+				CB9350091AE5032800756186 /* Images.xcassets in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		CB93500F1AE5032900756186 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXResourcesBuildPhase section */
+
+/* Begin PBXSourcesBuildPhase section */
+		CB934FF81AE5032500756186 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				CB9350271AE5037F00756186 /* KSTokenField.swift in Sources */,
+				CB9350041AE5032700756186 /* ViewController.swift in Sources */,
+				CB93502B1AE5045E00756186 /* List.swift in Sources */,
+				CB9350021AE5032700756186 /* AppDelegate.swift in Sources */,
+				CB9350291AE5037F00756186 /* KSUtils.swift in Sources */,
+				CB9350261AE5037F00756186 /* KSToken.swift in Sources */,
+				CB9350281AE5037F00756186 /* KSTokenView.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		CB93500D1AE5032900756186 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				CB9350181AE5032900756186 /* StackViewExampleTests.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXSourcesBuildPhase section */
+
+/* Begin PBXTargetDependency section */
+		CB9350131AE5032900756186 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = CB934FFB1AE5032500756186 /* StackViewExample */;
+			targetProxy = CB9350121AE5032900756186 /* PBXContainerItemProxy */;
+		};
+/* End PBXTargetDependency section */
+
+/* Begin PBXVariantGroup section */
+		CB9350051AE5032800756186 /* Main.storyboard */ = {
+			isa = PBXVariantGroup;
+			children = (
+				CB9350061AE5032800756186 /* Base */,
+			);
+			name = Main.storyboard;
+			sourceTree = "<group>";
+		};
+		CB93500A1AE5032900756186 /* LaunchScreen.xib */ = {
+			isa = PBXVariantGroup;
+			children = (
+				CB93500B1AE5032900756186 /* Base */,
+			);
+			name = LaunchScreen.xib;
+			sourceTree = "<group>";
+		};
+/* End PBXVariantGroup section */
+
+/* Begin XCBuildConfiguration section */
+		CB9350191AE5032900756186 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_TESTABILITY = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu99;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				GCC_SYMBOLS_PRIVATE_EXTERN = NO;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 9.3;
+				MTL_ENABLE_DEBUG_INFO = YES;
+				ONLY_ACTIVE_ARCH = YES;
+				SDKROOT = iphoneos;
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Debug;
+		};
+		CB93501A1AE5032900756186 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu99;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 9.3;
+				MTL_ENABLE_DEBUG_INFO = NO;
+				SDKROOT = iphoneos;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				VALIDATE_PRODUCT = YES;
+			};
+			name = Release;
+		};
+		CB93501C1AE5032900756186 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				INFOPLIST_FILE = StackViewExample/Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = "com.khawar.$(PRODUCT_NAME:rfc1034identifier)";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+			};
+			name = Debug;
+		};
+		CB93501D1AE5032900756186 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				INFOPLIST_FILE = StackViewExample/Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = "com.khawar.$(PRODUCT_NAME:rfc1034identifier)";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+			};
+			name = Release;
+		};
+		CB93501F1AE5032900756186 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(SDKROOT)/Developer/Library/Frameworks",
+					"$(inherited)",
+				);
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				INFOPLIST_FILE = StackViewExample/Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = "com.khawar.$(PRODUCT_NAME:rfc1034identifier)";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/StackViewExample.app/StackViewExample";
+			};
+			name = Debug;
+		};
+		CB9350201AE5032900756186 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(SDKROOT)/Developer/Library/Frameworks",
+					"$(inherited)",
+				);
+				INFOPLIST_FILE = StackViewExample/Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = "com.khawar.$(PRODUCT_NAME:rfc1034identifier)";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/StackViewExample.app/StackViewExample";
+			};
+			name = Release;
+		};
+/* End XCBuildConfiguration section */
+
+/* Begin XCConfigurationList section */
+		CB934FF71AE5032400756186 /* Build configuration list for PBXProject "StackViewExample" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				CB9350191AE5032900756186 /* Debug */,
+				CB93501A1AE5032900756186 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		CB93501B1AE5032900756186 /* Build configuration list for PBXNativeTarget "StackViewExample" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				CB93501C1AE5032900756186 /* Debug */,
+				CB93501D1AE5032900756186 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		CB93501E1AE5032900756186 /* Build configuration list for PBXNativeTarget "StackViewExampleTests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				CB93501F1AE5032900756186 /* Debug */,
+				CB9350201AE5032900756186 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+/* End XCConfigurationList section */
+	};
+	rootObject = CB934FF41AE5032400756186 /* Project object */;
+}

--- a/Examples/StackViewExample/StackViewExample.xcodeproj/project.xcworkspace/contents.xcworkspacedata
+++ b/Examples/StackViewExample/StackViewExample.xcodeproj/project.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "self:AutolayoutExample.xcodeproj">
+   </FileRef>
+</Workspace>

--- a/Examples/StackViewExample/StackViewExample/AppDelegate.swift
+++ b/Examples/StackViewExample/StackViewExample/AppDelegate.swift
@@ -1,0 +1,62 @@
+//
+//  AppDelegate.swift
+//  StackViewExample
+//
+//  Created by Khawar Shahzad on 11/05/2015.
+//  Copyright (c) 2015 Khawar Shahzad. All rights reserved.
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to
+//  deal in the Software without restriction, including without limitation the
+//  rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+//  sell copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+//  OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+//  WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR
+//  IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+import UIKit
+
+@UIApplicationMain
+class AppDelegate: UIResponder, UIApplicationDelegate {
+
+   var window: UIWindow?
+
+
+   func application(application: UIApplication, didFinishLaunchingWithOptions launchOptions: [NSObject: AnyObject]?) -> Bool {
+      // Override point for customization after application launch.
+      return true
+   }
+
+   func applicationWillResignActive(application: UIApplication) {
+      // Sent when the application is about to move from active to inactive state. This can occur for certain types of temporary interruptions (such as an incoming phone call or SMS message) or when the user quits the application and it begins the transition to the background state.
+      // Use this method to pause ongoing tasks, disable timers, and throttle down OpenGL ES frame rates. Games should use this method to pause the game.
+   }
+
+   func applicationDidEnterBackground(application: UIApplication) {
+      // Use this method to release shared resources, save user data, invalidate timers, and store enough application state information to restore your application to its current state in case it is terminated later.
+      // If your application supports background execution, this method is called instead of applicationWillTerminate: when the user quits.
+   }
+
+   func applicationWillEnterForeground(application: UIApplication) {
+      // Called as part of the transition from the background to the inactive state; here you can undo many of the changes made on entering the background.
+   }
+
+   func applicationDidBecomeActive(application: UIApplication) {
+      // Restart any tasks that were paused (or not yet started) while the application was inactive. If the application was previously in the background, optionally refresh the user interface.
+   }
+
+   func applicationWillTerminate(application: UIApplication) {
+      // Called when the application is about to terminate. Save data if appropriate. See also applicationDidEnterBackground:.
+   }
+
+
+}
+

--- a/Examples/StackViewExample/StackViewExample/Base.lproj/LaunchScreen.xib
+++ b/Examples/StackViewExample/StackViewExample/Base.lproj/LaunchScreen.xib
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="10116" systemVersion="15E65" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" launchScreen="YES" useTraitCollections="YES">
+    <dependencies>
+        <deployment identifier="iOS"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="10085"/>
+        <capability name="Constraints with non-1.0 multipliers" minToolsVersion="5.1"/>
+    </dependencies>
+    <objects>
+        <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner"/>
+        <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
+        <view contentMode="scaleToFill" id="iN0-l3-epB">
+            <rect key="frame" x="0.0" y="0.0" width="480" height="480"/>
+            <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+            <subviews>
+                <label opaque="NO" clipsSubviews="YES" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="  Copyright (c) 2015 Khawar Shahzad. All rights reserved." textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumFontSize="9" translatesAutoresizingMaskIntoConstraints="NO" id="8ie-xW-0ye">
+                    <rect key="frame" x="20" y="439" width="441" height="21"/>
+                    <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                    <color key="textColor" cocoaTouchSystemColor="darkTextColor"/>
+                    <nil key="highlightedColor"/>
+                </label>
+                <label opaque="NO" clipsSubviews="YES" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="StackViewExample" textAlignment="center" lineBreakMode="middleTruncation" baselineAdjustment="alignBaselines" minimumFontSize="18" translatesAutoresizingMaskIntoConstraints="NO" id="kId-c2-rCX">
+                    <rect key="frame" x="20" y="140" width="441" height="43"/>
+                    <fontDescription key="fontDescription" type="boldSystem" pointSize="36"/>
+                    <color key="textColor" cocoaTouchSystemColor="darkTextColor"/>
+                    <nil key="highlightedColor"/>
+                </label>
+            </subviews>
+            <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="calibratedWhite"/>
+            <constraints>
+                <constraint firstItem="kId-c2-rCX" firstAttribute="centerY" secondItem="iN0-l3-epB" secondAttribute="bottom" multiplier="1/3" constant="1" id="5cJ-9S-tgC"/>
+                <constraint firstAttribute="centerX" secondItem="kId-c2-rCX" secondAttribute="centerX" id="Koa-jz-hwk"/>
+                <constraint firstAttribute="bottom" secondItem="8ie-xW-0ye" secondAttribute="bottom" constant="20" id="Kzo-t9-V3l"/>
+                <constraint firstItem="8ie-xW-0ye" firstAttribute="leading" secondItem="iN0-l3-epB" secondAttribute="leading" constant="20" symbolic="YES" id="MfP-vx-nX0"/>
+                <constraint firstAttribute="centerX" secondItem="8ie-xW-0ye" secondAttribute="centerX" id="ZEH-qu-HZ9"/>
+                <constraint firstItem="kId-c2-rCX" firstAttribute="leading" secondItem="iN0-l3-epB" secondAttribute="leading" constant="20" symbolic="YES" id="fvb-Df-36g"/>
+            </constraints>
+            <nil key="simulatedStatusBarMetrics"/>
+            <freeformSimulatedSizeMetrics key="simulatedDestinationMetrics"/>
+            <point key="canvasLocation" x="548" y="455"/>
+        </view>
+    </objects>
+</document>

--- a/Examples/StackViewExample/StackViewExample/Base.lproj/Main.storyboard
+++ b/Examples/StackViewExample/StackViewExample/Base.lproj/Main.storyboard
@@ -1,0 +1,58 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="10116" systemVersion="15E65" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" initialViewController="BYZ-38-t0r">
+    <dependencies>
+        <deployment identifier="iOS"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="10085"/>
+        <capability name="Constraints to layout margins" minToolsVersion="6.0"/>
+    </dependencies>
+    <scenes>
+        <!--View Controller-->
+        <scene sceneID="tne-QT-ifu">
+            <objects>
+                <viewController id="BYZ-38-t0r" customClass="ViewController" customModule="StackViewExample" customModuleProvider="target" sceneMemberID="viewController">
+                    <layoutGuides>
+                        <viewControllerLayoutGuide type="top" id="y3c-jy-aDJ"/>
+                        <viewControllerLayoutGuide type="bottom" id="wfy-db-euE"/>
+                    </layoutGuides>
+                    <view key="view" contentMode="scaleToFill" id="8bC-Xf-vdC">
+                        <rect key="frame" x="0.0" y="0.0" width="600" height="600"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <subviews>
+                            <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" distribution="equalSpacing" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="mKJ-Pf-Jf9">
+                                <rect key="frame" x="20" y="20" width="560" height="88"/>
+                                <subviews>
+                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label above" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="hWC-4A-qpm">
+                                        <rect key="frame" x="0.0" y="0.0" width="560" height="21"/>
+                                        <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                        <color key="textColor" cocoaTouchSystemColor="darkTextColor"/>
+                                        <nil key="highlightedColor"/>
+                                    </label>
+                                    <view clipsSubviews="YES" contentMode="scaleToFill" placeholderIntrinsicWidth="560" placeholderIntrinsicHeight="30" translatesAutoresizingMaskIntoConstraints="NO" id="XRo-Ub-Gua" customClass="KSTokenView" customModule="StackViewExample" customModuleProvider="target">
+                                        <rect key="frame" x="0.0" y="29" width="560" height="30"/>
+                                        <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                                    </view>
+                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label below" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="A9f-og-Ael">
+                                        <rect key="frame" x="0.0" y="67" width="560" height="21"/>
+                                        <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                        <color key="textColor" cocoaTouchSystemColor="darkTextColor"/>
+                                        <nil key="highlightedColor"/>
+                                    </label>
+                                </subviews>
+                            </stackView>
+                        </subviews>
+                        <color key="backgroundColor" red="0.2901960784" green="0.6705882353" blue="0.96862745100000003" alpha="1" colorSpace="calibratedRGB"/>
+                        <constraints>
+                            <constraint firstItem="mKJ-Pf-Jf9" firstAttribute="top" secondItem="y3c-jy-aDJ" secondAttribute="bottom" id="M7m-aN-XZ5"/>
+                            <constraint firstItem="mKJ-Pf-Jf9" firstAttribute="trailing" secondItem="8bC-Xf-vdC" secondAttribute="trailingMargin" id="v5F-UT-XXz"/>
+                            <constraint firstItem="mKJ-Pf-Jf9" firstAttribute="leading" secondItem="8bC-Xf-vdC" secondAttribute="leadingMargin" id="xJV-Yw-6WN"/>
+                        </constraints>
+                    </view>
+                    <connections>
+                        <outlet property="tokenView" destination="XRo-Ub-Gua" id="8gj-cx-4zf"/>
+                    </connections>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="dkx-z0-nzr" sceneMemberID="firstResponder"/>
+            </objects>
+        </scene>
+    </scenes>
+</document>

--- a/Examples/StackViewExample/StackViewExample/Images.xcassets/AppIcon.appiconset/Contents.json
+++ b/Examples/StackViewExample/StackViewExample/Images.xcassets/AppIcon.appiconset/Contents.json
@@ -1,0 +1,73 @@
+{
+  "images" : [
+    {
+      "idiom" : "iphone",
+      "size" : "29x29",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "iphone",
+      "size" : "29x29",
+      "scale" : "3x"
+    },
+    {
+      "idiom" : "iphone",
+      "size" : "40x40",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "iphone",
+      "size" : "40x40",
+      "scale" : "3x"
+    },
+    {
+      "idiom" : "iphone",
+      "size" : "60x60",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "iphone",
+      "size" : "60x60",
+      "scale" : "3x"
+    },
+    {
+      "idiom" : "ipad",
+      "size" : "29x29",
+      "scale" : "1x"
+    },
+    {
+      "idiom" : "ipad",
+      "size" : "29x29",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "ipad",
+      "size" : "40x40",
+      "scale" : "1x"
+    },
+    {
+      "idiom" : "ipad",
+      "size" : "40x40",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "ipad",
+      "size" : "76x76",
+      "scale" : "1x"
+    },
+    {
+      "idiom" : "ipad",
+      "size" : "76x76",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "ipad",
+      "size" : "83.5x83.5",
+      "scale" : "2x"
+    }
+  ],
+  "info" : {
+    "version" : 1,
+    "author" : "xcode"
+  }
+}

--- a/Examples/StackViewExample/StackViewExample/Images.xcassets/background-oversize.imageset/Contents.json
+++ b/Examples/StackViewExample/StackViewExample/Images.xcassets/background-oversize.imageset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "images" : [
+    {
+      "idiom" : "universal",
+      "scale" : "1x"
+    },
+    {
+      "idiom" : "universal",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "universal",
+      "scale" : "3x"
+    }
+  ],
+  "info" : {
+    "version" : 1,
+    "author" : "xcode"
+  }
+}

--- a/Examples/StackViewExample/StackViewExample/Images.xcassets/background.imageset/Contents.json
+++ b/Examples/StackViewExample/StackViewExample/Images.xcassets/background.imageset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "images" : [
+    {
+      "idiom" : "universal",
+      "scale" : "1x"
+    },
+    {
+      "idiom" : "universal",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "universal",
+      "scale" : "3x"
+    }
+  ],
+  "info" : {
+    "version" : 1,
+    "author" : "xcode"
+  }
+}

--- a/Examples/StackViewExample/StackViewExample/Info.plist
+++ b/Examples/StackViewExample/StackViewExample/Info.plist
@@ -1,0 +1,51 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>UIAppFonts</key>
+	<array>
+		<string>magnolia_sky.ttf</string>
+	</array>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>en</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>APPL</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleSignature</key>
+	<string>????</string>
+	<key>CFBundleVersion</key>
+	<string>1</string>
+	<key>LSRequiresIPhoneOS</key>
+	<true/>
+	<key>UILaunchStoryboardName</key>
+	<string>LaunchScreen</string>
+	<key>UIMainStoryboardFile</key>
+	<string>Main</string>
+	<key>UIRequiredDeviceCapabilities</key>
+	<array>
+		<string>armv7</string>
+	</array>
+	<key>UISupportedInterfaceOrientations</key>
+	<array>
+		<string>UIInterfaceOrientationPortrait</string>
+		<string>UIInterfaceOrientationLandscapeLeft</string>
+		<string>UIInterfaceOrientationLandscapeRight</string>
+	</array>
+	<key>UISupportedInterfaceOrientations~ipad</key>
+	<array>
+		<string>UIInterfaceOrientationPortrait</string>
+		<string>UIInterfaceOrientationPortraitUpsideDown</string>
+		<string>UIInterfaceOrientationLandscapeLeft</string>
+		<string>UIInterfaceOrientationLandscapeRight</string>
+	</array>
+</dict>
+</plist>

--- a/Examples/StackViewExample/StackViewExample/ViewController.swift
+++ b/Examples/StackViewExample/StackViewExample/ViewController.swift
@@ -1,0 +1,77 @@
+//
+//  ViewController.swift
+//  StackViewExample
+//
+//  Created by Khawar Shahzad on 11/05/2015.
+//  Copyright (c) 2015 Khawar Shahzad. All rights reserved.
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to
+//  deal in the Software without restriction, including without limitation the
+//  rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+//  sell copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+//  OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+//  WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR
+//  IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+import UIKit
+
+class ViewController: UIViewController {
+
+   @IBOutlet var tokenView: KSTokenView!
+   let names: Array<String> = List.names()
+   
+   override func viewDidLoad() {
+      super.viewDidLoad()
+      
+      tokenView.delegate = self
+      tokenView.promptText = "Top 5: "
+      tokenView.placeholder = "Type to search"
+      tokenView.descriptionText = "Languages"
+      tokenView.maxTokenLimit = 5
+      tokenView.minimumCharactersToSearch = 0 // Show all results without without typing anything
+      tokenView.style = .Squared
+   }
+
+   override func didReceiveMemoryWarning() {
+      super.didReceiveMemoryWarning()
+      // Dispose of any resources that can be recreated.
+   }
+}
+
+
+extension ViewController: KSTokenViewDelegate {
+   func tokenView(token: KSTokenView, performSearchWithString string: String, completion: ((results: Array<AnyObject>) -> Void)?) {
+      if (string.characters.isEmpty){
+         completion!(results: names)
+         return
+      }
+      
+      var data: Array<String> = []
+      for value: String in names {
+         if value.lowercaseString.rangeOfString(string.lowercaseString) != nil {
+            data.append(value)
+         }
+      }
+      completion!(results: data)
+   }
+   
+   func tokenView(token: KSTokenView, displayTitleForObject object: AnyObject) -> String {
+      return object as! String
+   }
+   
+   func tokenView(tokenView: KSTokenView, shouldAddToken token: KSToken) -> Bool {
+      if token.title == "f" {
+         return false
+      }
+      return true
+   }
+}

--- a/Examples/StackViewExample/StackViewExampleTests/Info.plist
+++ b/Examples/StackViewExample/StackViewExampleTests/Info.plist
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>en</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>BNDL</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleSignature</key>
+	<string>????</string>
+	<key>CFBundleVersion</key>
+	<string>1</string>
+</dict>
+</plist>

--- a/Examples/StackViewExample/StackViewExampleTests/StackViewExampleTests.swift
+++ b/Examples/StackViewExample/StackViewExampleTests/StackViewExampleTests.swift
@@ -1,0 +1,36 @@
+//
+//  StackViewExampleTests.swift
+//  StackViewExample
+//
+//  Created by Khawar Shahzad on 11/05/2015.
+//  Copyright (c) 2015 Khawar Shahzad. All rights reserved.
+//
+
+import UIKit
+import XCTest
+
+class StackViewExampleTests: XCTestCase {
+    
+    override func setUp() {
+        super.setUp()
+        // Put setup code here. This method is called before the invocation of each test method in the class.
+    }
+    
+    override func tearDown() {
+        // Put teardown code here. This method is called after the invocation of each test method in the class.
+        super.tearDown()
+    }
+    
+    func testExample() {
+        // This is an example of a functional test case.
+        XCTAssert(true, "Pass")
+    }
+    
+    func testPerformanceExample() {
+        // This is an example of a performance test case.
+        self.measureBlock() {
+            // Put the code you want to measure the time of here.
+        }
+    }
+    
+}

--- a/Examples/SwiftExample/SwiftExample/Base.lproj/Main.storyboard
+++ b/Examples/SwiftExample/SwiftExample/Base.lproj/Main.storyboard
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="6250" systemVersion="14B25" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" initialViewController="BYZ-38-t0r">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="10116" systemVersion="15E65" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" initialViewController="BYZ-38-t0r">
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="6244"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="10085"/>
         <capability name="Constraints to layout margins" minToolsVersion="6.0"/>
     </dependencies>
     <scenes>
@@ -18,11 +18,10 @@
                         <rect key="frame" x="0.0" y="0.0" width="600" height="600"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
-                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="9X8-WR-bnd" customClass="KSTokenView" customModule="SwiftExample" customModuleProvider="target">
-                                <rect key="frame" x="26" y="30" width="300" height="30"/>
+                            <view contentMode="scaleToFill" placeholderIntrinsicWidth="infinite" placeholderIntrinsicHeight="30" translatesAutoresizingMaskIntoConstraints="NO" id="9X8-WR-bnd" customClass="KSTokenView" customModule="SwiftExample" customModuleProvider="target">
+                                <rect key="frame" x="30" y="30" width="300" height="30"/>
                                 <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                                 <constraints>
-                                    <constraint firstAttribute="height" constant="30" id="DD8-EU-Z7S"/>
                                     <constraint firstAttribute="width" constant="300" id="Ppi-M1-tbJ"/>
                                 </constraints>
                             </view>

--- a/KSTokenView/KSTokenView.swift
+++ b/KSTokenView/KSTokenView.swift
@@ -102,6 +102,7 @@ public class KSTokenView: UIView {
    private var _indicator = UIActivityIndicatorView(activityIndicatorStyle: UIActivityIndicatorViewStyle.Gray)
    private let _searchResultHeight: CGFloat = 200.0
    private var _lastSearchString: String = ""
+   private var _intrinsicContentHeight: CGFloat = UIViewNoIntrinsicMetric
    
    //MARK: - Public Properties
    //__________________________________________________________________________________
@@ -384,12 +385,13 @@ public class KSTokenView: UIView {
    
    private func _commonSetup() {
       backgroundColor = UIColor.clearColor()
+      clipsToBounds = true
       _tokenField = KSTokenField(frame: CGRect(x: 0, y: 0, width: self.bounds.width, height: self.bounds.height))
       _tokenField.textColor = UIColor.blackColor()
       _tokenField.enabled = true
       _tokenField.tokenFieldDelegate = self
       _tokenField.placeholder = ""
-      _tokenField.autoresizingMask = [.FlexibleWidth, .FlexibleHeight]
+      _tokenField.autoresizingMask = [.FlexibleWidth]
       _updateTokenField()
       addSubview(_tokenField)
       
@@ -403,8 +405,9 @@ public class KSTokenView: UIView {
       _searchTableView.delegate = self
       _searchTableView.dataSource = self
       
-      addSubview(_searchTableView)
       _hideSearchResults()
+      _intrinsicContentHeight = _tokenField.bounds.height
+      invalidateIntrinsicContentSize()
    }
    
    //MARK: - Layout changes
@@ -415,6 +418,10 @@ public class KSTokenView: UIView {
       _searchTableView.frame.size = CGSize(width: frame.width, height: searchResultSize.height)
    }
    
+    override public func intrinsicContentSize() -> CGSize {
+        return CGSize(width: UIViewNoIntrinsicMetric, height: _intrinsicContentHeight)
+    }
+    
    //MARK: - Private Methods
    //__________________________________________________________________________________
    //
@@ -706,29 +713,32 @@ public class KSTokenView: UIView {
       _showSearchResults()
    }
    
-   private func _showSearchResults() {
-      if (_tokenField.isFirstResponder()) {
-         _showingSearchResult = true
-         addSubview(_searchTableView)
-         _searchTableView.frame.origin = CGPoint(x: 0, y: bounds.height)
-         _searchTableView.hidden = false
-      }
-      delegate?.tokenViewDidShowSearchResults?(self)
-   }
+    private func _showSearchResults() {
+        guard !_showingSearchResult else {return}
+        _showingSearchResult = true
+        addSubview(_searchTableView)
+        let tokenFieldHeight = _tokenField.frame.height
+        _searchTableView.hidden = false
+        _changeHeight(tokenFieldHeight)
+        delegate?.tokenViewDidShowSearchResults?(self)
+    }
    
-   private func _hideSearchResults() {
-      _showingSearchResult = false
-      _searchTableView.hidden = true
-      _searchTableView.removeFromSuperview()
-      delegate?.tokenViewDidHideSearchResults?(self)
-   }
+    private func _hideSearchResults() {
+        guard _showingSearchResult else {return}
+        _showingSearchResult = false
+        let searchTableView = self._searchTableView
+        _changeHeight(_tokenField.frame.height) {
+            searchTableView.hidden = true
+            searchTableView.removeFromSuperview()
+        }
+        delegate?.tokenViewDidHideSearchResults?(self)
+    }
    
-   private func _repositionSearchResults() {
+    private func _repositionSearchResults(height: CGFloat) {
       if (!_showingSearchResult) {
          return
       }
-      _searchTableView.frame.origin = CGPoint(x: 0, y: bounds.height)
-      _searchTableView.layoutIfNeeded()
+      _searchTableView.frame.origin = CGPoint(x: 0, y: height)
    }
    
    private func _filteredSearchResults(results: Array <AnyObject>) -> Array <AnyObject> {
@@ -776,21 +786,28 @@ public class KSTokenView: UIView {
       _indicator.stopAnimating()
       _searchTableView.tableHeaderView = nil
    }
-   
-   //MARK: - HitTest for _searchTableView
-   //__________________________________________________________________________________
-   //
-   
-   override public func hitTest(point: CGPoint, withEvent event: UIEvent?) -> UIView? {
-      if (_showingSearchResult) {
-         let pointForTargetView = _searchTableView.convertPoint(point, fromView: self)
-         
-         if (CGRectContainsPoint(_searchTableView.bounds, pointForTargetView)) {
-            return _searchTableView.hitTest(pointForTargetView, withEvent: event)
-         }
-      }
-      return super.hitTest(point, withEvent: event)
-   }
+    
+    private func _changeHeight(tokenFieldHeight: CGFloat, completion: (() -> Void)? = nil) {
+        let fullHeight = tokenFieldHeight + (_showingSearchResult ? _searchResultHeight : 0.0)
+        delegate?.tokenView?(self, willChangeFrameWithX: frame.origin.x, y: frame.origin.y, width: frame.size.width, height: fullHeight)
+        self._repositionSearchResults(tokenFieldHeight)
+        
+        UIView.animateWithDuration(
+            animateDuration,
+            animations: {
+                self._tokenField.frame.size.height = tokenFieldHeight
+                self.frame.size.height = fullHeight
+                self._intrinsicContentHeight = fullHeight
+                self.invalidateIntrinsicContentSize()
+                self.superview?.layoutIfNeeded()
+            },
+            completion: {completed in
+                completion?()
+                if (completed) {
+                    self.delegate?.tokenView?(self, didChangeFrameWithX: self.frame.origin.x, y: self.frame.origin.y, width: self.frame.size.width, height: fullHeight)
+                }
+        })
+    }
    
    //MARK: - Memory Mangement
    //__________________________________________________________________________________
@@ -810,33 +827,7 @@ extension KSTokenView : KSTokenFieldDelegate {
    }
    
    func tokenFieldShouldChangeHeight(height: CGFloat) {
-      // Temporarily fixed issue of "command failed due to signal segmentation fault 11 CGRect"
-      delegate?.tokenView?(self, willChangeFrameWithX: frame.origin.x, y: frame.origin.y, width: frame.size.width, height: frame.size.height)
-      frame.size.height = height
-      
-      UIView.animateWithDuration(
-         animateDuration,
-         animations: {
-            self.frame.size.height = height
-            
-            if (KSUtils.constrainsEnabled(self)) {
-               for index in 0 ... self.constraints.count-1 {
-                  let constraint: NSLayoutConstraint = self.constraints[index] as NSLayoutConstraint
-                  
-                  if (constraint.firstItem as! NSObject == self && constraint.firstAttribute == .Height) {
-                     constraint.constant = height
-                  }
-               }
-            }
-            
-            self._repositionSearchResults()
-         },
-         completion: {completed in
-            if (completed) {
-               // Temporarily fixed issue of "command failed due to signal segmentation fault 11 CGRect"
-               self.delegate?.tokenView?(self, didChangeFrameWithX: self.frame.origin.x, y: self.frame.origin.y, width: self.frame.size.width, height: self.frame.size.height)
-            }
-      })
+      _changeHeight(height)
    }
 }
 

--- a/KSTokenView/KSUtils.swift
+++ b/KSTokenView/KSUtils.swift
@@ -48,14 +48,6 @@ class KSUtils : NSObject {
       return attributedString.size().width
    }
    
-   class func constrainsEnabled(view: UIView) -> Bool {
-      if (view.constraints.count > 0) {
-         return true
-      } else {
-         return false
-      }
-   }
-   
 }
 
 extension UIColor {


### PR DESCRIPTION
The approach of handling autolayout by searching for and manipulating height constraints is error-prone. Additionally the fact that the search results table is outside the bounds of the KSTokenView doesn't work well when the KSTokenView is in a UIStackView.

This patch handles autolayout by giving the KSTokenView the correct, dynamic instrinsicContentSize and including the search results table within the bounds of the KSTokenView. This gives correct behaviour in all circumstances.

Existing projects where the KSTokenView is in Interface Builder should remove any height constraints on the KSTokenView and instead give it a placeholder intrinsic content size in IB with width "none" and height 30 (for example).

Also, KSTokenView now works just fine when clipsToBounds is true, which can give a small performance gain.

I have also added a new example project that uses a UIStackView.