### PR TITLE
Conform placeholder font and baseline

### DIFF
--- a/KSTokenView/KSTokenField.swift
+++ b/KSTokenView/KSTokenField.swift
@@ -602,8 +602,8 @@ public class KSTokenField: UITextField {
       if (_placeholderLabel == nil) {
          _placeholderLabel = UILabel(frame: CGRect(x: xPos, y: leftView!.frame.origin.y-5, width: _selfFrame!.width - xPos - _leftViewRect().size.width, height: 30))
          _placeholderLabel?.textColor = placeHolderColor
+         _placeholderLabel?.font = _font
          _scrollView.addSubview(_placeholderLabel!)
-         
       } else {
          _placeholderLabel?.frame.origin.x = xPos
       }

--- a/KSTokenView/KSTokenField.swift
+++ b/KSTokenView/KSTokenField.swift
@@ -590,6 +590,7 @@ public class KSTokenField: UITextField {
    private func _updatePlaceHolderVisibility() {
       if tokens.count == 0 && (text == KSTextEmpty || text!.isEmpty) {
          _placeholderLabel?.text = _placeholderValue!
+         _placeholderLabel?.sizeToFit()
          _placeholderLabel?.hidden = false
          
       } else {
@@ -600,7 +601,7 @@ public class KSTokenField: UITextField {
    private func _initPlaceholderLabel() {
       let xPos = _marginX!
       if (_placeholderLabel == nil) {
-         _placeholderLabel = UILabel(frame: CGRect(x: xPos, y: leftView!.frame.origin.y-5, width: _selfFrame!.width - xPos - _leftViewRect().size.width, height: 30))
+         _placeholderLabel = UILabel(frame: CGRect(x: xPos, y: leftView!.frame.origin.y, width: _selfFrame!.width - xPos - _leftViewRect().size.width, height: _leftViewRect().size.height))
          _placeholderLabel?.textColor = placeHolderColor
          _placeholderLabel?.font = _font
          _scrollView.addSubview(_placeholderLabel!)


### PR DESCRIPTION
This patch makes the placeholder use the same font as the rest of the view and conforms its baseline to the prompt label.