### PR TITLE
Expose KSToken maxWidth property as public

### DIFF
--- a/KSTokenView/KSToken.swift
+++ b/KSTokenView/KSToken.swift
@@ -73,7 +73,7 @@ public class KSToken : UIControl {
 
    /// default is 200. Maximum width of token. After maximum limit is reached title is truncated at end with '...'
    private var _maxWidth: CGFloat? = 200
-   var maxWidth: CGFloat {
+   public var maxWidth: CGFloat {
       get{
          return _maxWidth!
       }


### PR DESCRIPTION
This PR simply changes the KSToken maxWidth property to be `public`, rather than an implicit `internal`.   

Since there's the private var right above, my guess is this was just missed at some point.