### PR TITLE
Allowing adjusted search result size height to take effect.

### DIFF
--- a/KSTokenView/KSTokenView.swift
+++ b/KSTokenView/KSTokenView.swift
@@ -788,7 +788,7 @@ open class KSTokenView: UIView {
    }
     
     fileprivate func _changeHeight(_ tokenFieldHeight: CGFloat, completion: (() -> Void)? = nil) {
-        let fullHeight = tokenFieldHeight + (_showingSearchResult ? _searchResultHeight : 0.0)
+        let fullHeight = tokenFieldHeight + (_showingSearchResult ? searchResultSize.height : 0.0)
         delegate?.tokenView?(self, willChangeFrameWithX: frame.origin.x, y: frame.origin.y, width: frame.size.width, height: fullHeight)
         self._repositionSearchResults(tokenFieldHeight)
         


### PR DESCRIPTION
Calling searchResultSize had no effect as the constant _searchResultHeight got used in _changeHeight function.
This change allows adjusted search result size height to take effect.