### PR TITLE
Allowing custom text color for tokenField.

### DIFF
--- a/KSTokenView/KSTokenView.swift
+++ b/KSTokenView/KSTokenView.swift
@@ -327,6 +327,13 @@ open class KSTokenView: UIView {
       }
    }
 
+    /// default is UIColor.blackColor()
+    open var textColor: UIColor = UIColor.black {
+        didSet {
+            _tokenField.textColor = textColor
+        }
+    }
+
     /// default is UIColor.grayColor()
     open var promptColor: UIColor = UIColor.gray {
         didSet {

--- a/README.md
+++ b/README.md
@@ -118,6 +118,9 @@ tokenView.maximumHeight = 120.0
 /// default is UIColor.grayColor()
 tokenView.cursorColor = UIColor.grayColor()
 
+/// default is UIColor.blackColor()
+tokenView.textColor = UIColor.blackColor()
+
 /// default is 10.0. Horizontal padding of title
 tokenView.paddingX = 10.0
 


### PR DESCRIPTION
Was unable to set a custom color for the text of the tokenField (UITextField) so as one types, the text color is always default color black.
This change makes it possible to set custom text color.