### PR TITLE
added an option to hide search results view when a token is deleted.

### DIFF
--- a/KSTokenView/KSTokenView.swift
+++ b/KSTokenView/KSTokenView.swift
@@ -120,6 +120,9 @@ open class KSTokenView: UIView {
    
    /// default is true. token can be deleted with keyboard 'x' button
    @objc open var shouldDeleteTokenOnBackspace = true
+    
+   /// default is true. token can be deleted with keyboard 'x' button
+   @objc open var shouldHideSearchResultsWhenTokenIsDeleted = false
    
    /// Only works for iPhone now, not iPad devices. default is false. If true, search results are hidden when one of them is selected
    @objc open var shouldHideSearchResultsOnSelect = false
@@ -853,6 +856,9 @@ extension KSTokenView : UITextFieldDelegate {
          if (_lastToken() != nil) {
             if (selectedToken() != nil) {
                deleteSelectedToken()
+               if shouldHideSearchResultsWhenTokenIsDeleted {
+                  _hideSearchResults()
+               }
             } else {
                _tokenField.selectToken(_lastToken()!)
             }


### PR DESCRIPTION
Sometimes there is no need to show the search results view when you delete a token.
This pull request add an option to hide the search results view when a token is deleted.