### PR TITLE
fix for #52

### DIFF
--- a/KSTokenView/KSTokenView.swift
+++ b/KSTokenView/KSTokenView.swift
@@ -374,7 +374,7 @@ open class KSTokenView: UIView {
    */
    required public init?(coder aDecoder: NSCoder) {
       super.init(coder: aDecoder)
-      _commonSetup
+      _commonSetup()
    }
    
    override open func awakeFromNib() {

--- a/KSTokenView/KSTokenView.swift
+++ b/KSTokenView/KSTokenView.swift
@@ -374,6 +374,7 @@ open class KSTokenView: UIView {
    */
    required public init?(coder aDecoder: NSCoder) {
       super.init(coder: aDecoder)
+      _commonSetup
    }
    
    override open func awakeFromNib() {


### PR DESCRIPTION
Hi,

Setting up the TokenView from interface builder inside a cell results in a crash due to the TokenField being Nil. This fix will make sure it loads properly. 