### PR TITLE
update height on layout - Fix for #118

### DIFF
--- a/KSTokenView/KSTokenView.swift
+++ b/KSTokenView/KSTokenView.swift
@@ -416,6 +416,8 @@ open class KSTokenView: UIView {
    override open func layoutSubviews() {
       _tokenField.updateLayout(false)
       _searchTableView.frame.size = CGSize(width: frame.width, height: _searchResultHeight)
+      self.invalidateIntrinsicContentSize()
+      self.frame.size.height = _intrinsicContentHeight
    }
    
     override open var intrinsicContentSize : CGSize {


### PR DESCRIPTION
updated view height on layoutSubviews call to correctly update tableview height

Added following to layoutSubviews definition of KSTokenView:
`self.invalidateIntrinsicContentSize()`
`self.frame.size.height = _intrinsicContentHeight`